### PR TITLE
Rename package 'cmd' to 'command'

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -1,4 +1,4 @@
-package cmd
+package command
 
 import (
 	"fmt"

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -1,4 +1,4 @@
-package cmd
+package command
 
 import (
 	"os"

--- a/main.go
+++ b/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"fmt"
 
-	"watchit/cmd"
+	"watchit/command"
 )
 
 func main() {
-	c := cmd.Parse()
+	c := command.Parse()
 	fmt.Printf("%#v\n", c)
 }


### PR DESCRIPTION
'cmd' is a well-known go package. So, renamed the local package 'cmd' to
'command'.