### PR TITLE
Added rudimentary file watcher

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,11 +2,27 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	"watchit/command"
+	"watchit/watch"
 )
+
+func handler(op watch.Op, fileName string) {
+	fmt.Printf("op=%s file=%s", op.Name(), fileName)
+}
 
 func main() {
 	c := command.Parse()
 	fmt.Printf("%#v\n", c)
+
+	w := watch.New(c.Dirs, c.Cmds, c.Regex, c.Recursive, handler)
+
+	if err := w.Setup(); err != nil {
+		log.Fatalln("setting up watch failed")
+	}
+
+	if err := w.Start(); err != nil {
+		log.Fatalln("starting watch failed")
+	}
 }

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -1,0 +1,177 @@
+package watch
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"time"
+
+	"github.com/radovskyb/watcher"
+)
+
+// Op represents the file-operations to watch for. E.g., create, write,
+// remove, rename, etc.
+type Op uint32
+
+const (
+	// Create represents the event when a file is created in watched
+	// directory.
+	Create Op = iota
+
+	// Write represents the event when a watched file is written to.
+	Write
+
+	// Remove represents the event when a watched file is deleted.
+	Remove
+
+	// Rename represents the event when a watched file is renamed.
+	Rename
+
+	// Chmod represents the event when a watched file's premissions are
+	// changed.
+	Chmod
+
+	// Tbi represents the events that are yet to be supported.
+	Tbi
+)
+
+var opStr = map[Op]string{
+	Create: "CREATE",
+	Write:  "WRITE",
+	Remove: "REMOVE",
+	Rename: "RENAME",
+	Chmod:  "CHMOD",
+	Tbi:    "TBI",
+}
+
+// Handler is a pointer to handler function that users of 'watch'
+// package can register. It will be called on the event of any
+// operation, 'op', on the watched files, 'fileName'.
+type Handler func(Op, string)
+
+// Watch represents watcher configuration: dirctories, commands to
+// execute, file types, etc.
+type Watch struct {
+	// Directories to watch.
+	Dirs []string
+
+	// Commands to exectue on watched files.
+	Cmds []string
+
+	// Regex to apply to filter watched file names.
+	Regex string
+
+	// Watch directories recursively?
+	Recursive bool
+
+	// HandlerCB function to call on file-change events.
+	HandlerCB Handler
+
+	// Pointer to underlying watcher,
+	watcher *watcher.Watcher
+}
+
+// Name returns the human-redable name for Op.
+func (op Op) Name() string {
+	if opstr, present := opStr[op]; present {
+		return opstr
+	}
+
+	return "UNKNOWN"
+}
+
+// Translate 'watcher' package's event ops to our own.
+func xlate(wOp watcher.Op) Op {
+	switch wOp {
+	case watcher.Create:
+		return Create
+	case watcher.Write:
+		return Write
+	case watcher.Remove:
+		return Remove
+	case watcher.Rename:
+		return Rename
+	case watcher.Chmod:
+		return Chmod
+	default:
+		return Tbi
+	}
+}
+
+func (w *Watch) handleEvents() {
+	wr := w.watcher
+
+	for {
+		select {
+		case event := <-wr.Event:
+			w.HandlerCB(xlate(event.Op), event.Path)
+
+		case err := <-wr.Error:
+			fmt.Fprintf(os.Stderr, "%s", err)
+
+		case <-wr.Closed:
+			return
+		}
+	}
+}
+
+// New instantiates a new Watch struct.
+func New(
+	dirs, cmds []string,
+	regex string,
+	recursive bool,
+	handler Handler) *Watch {
+	w := Watch{dirs, cmds, regex, recursive, handler, watcher.New()}
+	return &w
+}
+
+// Start starts watching the configured directories via Setup().
+func (w *Watch) Start() error {
+	wr := w.watcher
+
+	// Start the event handler for the watcher before starting the
+	// watcher.
+	go w.handleEvents()
+
+	// Start watching for file changes.
+	if err := wr.Start(time.Second * 5); err != nil {
+		return (fmt.Errorf("failed to start watching files"))
+	}
+
+	fmt.Println(wr.WatchedFiles())
+
+	return nil
+}
+
+// Setup sets up a watcher on a directory for given set of files.
+func (w *Watch) Setup() error {
+	wr := w.watcher
+
+	// Allow at most 1 event to be received per watching cycle.
+	wr.SetMaxEvents(1)
+
+	// Only monitor if the file is written.
+	wr.FilterOps(watcher.Write)
+
+	// Apply regex filters for file names.
+	re, err := regexp.Compile(w.Regex)
+	if err != nil {
+		return (fmt.Errorf("couldn't compile regex: %s", w.Regex))
+	}
+	wr.AddFilterHook(watcher.RegexFilterHook(re, false))
+
+	// Watch user-given directories for changes.
+	for _, dir := range w.Dirs {
+		if w.Recursive {
+			if err := wr.AddRecursive(dir); err != nil {
+				return (fmt.Errorf("failed to watch recursive dir: %s", dir))
+			}
+		} else {
+			if err := wr.Add(dir); err != nil {
+				return (fmt.Errorf("failed to watch dir: %s", dir))
+			}
+		}
+	}
+
+	return nil
+}

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -1,0 +1,125 @@
+package watch
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var tempFiles = make(map[string]bool)
+
+func createDir(t *testing.T, path string, name string) string {
+	if len(path) == 0 {
+		path = "/tmp/watchit"
+	}
+
+	finalName := strings.Join([]string{path, name}, "/")
+	if err := os.MkdirAll(finalName, 0700); err != nil {
+		t.Fatalf(
+			"failed to create temp dir; path=%s name=%s err=%s",
+			path,
+			name,
+			err,
+		)
+	}
+
+	tempFiles[finalName] = true
+	return finalName
+}
+
+func createFile(t *testing.T, dir string, name string) *os.File {
+	finalName := strings.Join([]string{dir, name}, "/")
+
+	file, err := os.Create(finalName)
+	if err != nil {
+		t.Fatalf(
+			"failed to create temp file; dir=%s name=%s err=%s",
+			dir,
+			name,
+			err,
+		)
+	}
+
+	tempFiles[finalName] = true
+	return file
+}
+
+func removeFile(t *testing.T, name string) {
+	if err := os.Remove(name); err != nil {
+		t.Fatalf("failed to remove file: %s err=%s", name, err)
+	}
+
+	delete(tempFiles, name)
+}
+
+func writeToFile(t *testing.T, file *os.File, data string) {
+	_, err := file.WriteString(data)
+	if err != nil {
+		t.Fatalf(
+			"failed to write to temp file: file=%s data=%s err=%s",
+			file.Name(),
+			data,
+			err,
+		)
+	}
+}
+
+func renameFile(t *testing.T, oldName, newName string) {
+	if err := os.Rename(oldName, newName); err != nil {
+		t.Fatalf(
+			"failed to rename file: oldname=%s newname=%s err=%s",
+			oldName,
+			newName,
+			err,
+		)
+	}
+
+	delete(tempFiles, oldName)
+	tempFiles[newName] = true
+}
+
+func cleanup(t *testing.T) {
+	for file := range tempFiles {
+		if err := os.RemoveAll(file); err != nil {
+			t.Fatalf("failed to remove temp file: %s err=%s", file, err)
+		}
+	}
+
+	tempFiles = make(map[string]bool)
+}
+
+func TestFileOps(t *testing.T) {
+	defer cleanup(t)
+
+	dir := createDir(t, "", "test_basic")
+	file := createFile(t, dir, "test.md")
+	defer file.Close()
+
+	lines := []string{"hello, tests!\n", "bye, tests!\n"}
+
+	for _, line := range lines {
+		writeToFile(t, file, line)
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	buf := bufio.NewReader(file)
+	for _, line := range lines {
+		readLine, err := buf.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				continue
+			}
+			t.Fatalf(
+				"reading data from file failed; name=%s err=%s",
+				file.Name(),
+				err,
+			)
+		}
+		assert.Equal(t, line, readLine)
+	}
+}


### PR DESCRIPTION
Implemented a simple file watcher using 'watcher' package as 'watch'.

watch takes in the directories to watch (recursively, if provided) and a
regex filter to monitor file names matching the filter. It also takes in
a handler function that will be called whenever an event occurs on one
of the watched files. It currently watches only for 'write' events.

Also, added a basic test for fileops. This test file simply has helper
functions to create/delete/write/rename files. This will be used for
writing tests for 'watch' package.